### PR TITLE
Exit 0 succeeds pero mata build

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -38,4 +38,3 @@ echo "Cleaning up temp files"
 rm -Rf $TEMP_DIRECTORY
 
 echo "Deployed successfully."  
-exit 0


### PR DESCRIPTION
Al parecer el exit aunque exitoso evita que pasos adicionales definidos en el .travis.yml se ejecuten, solamente exit dirty si algo sale mal, de lo contrario no hacer un exit explicito.
